### PR TITLE
Update project colors and fonts

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#667eea" />
+    <meta name="theme-color" content="#6366F1" />
     <meta name="description" content="暑假计划助手 - 让孩子的暑假更有意义" />
     <title>暑假计划助手 - 智能时间轴版</title>
 </head>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,11 +2,37 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Theme variables */
+:root {
+  --color-bg: #f8fafc; /* slate-50 */
+  --color-text: #0f172a; /* slate-900 */
+}
+
+@layer base {
+  html {
+    color: var(--color-text);
+    background-color: var(--color-bg);
+  }
+  body {
+    @apply font-sans antialiased;
+  }
+  h1 {
+    @apply text-2xl md:text-3xl font-semibold text-slate-900;
+  }
+  h2 {
+    @apply text-xl md:text-2xl font-semibold text-slate-900;
+  }
+  h3 {
+    @apply text-lg md:text-xl font-semibold text-slate-900;
+  }
+  a {
+    @apply text-primary-600 hover:text-primary-700;
+  }
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: Inter, 'Noto Sans SC', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   /* Mobile optimizations */

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -6,30 +6,30 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        // Duolingo-inspired cartoon color palette
+        // Unified brand palette
         primary: {
-          50: '#f0f9ff',
-          100: '#e0f2fe',
-          200: '#bae6fd',
-          300: '#7dd3fc',
-          400: '#38bdf8',
-          500: '#0ea5e9',
-          600: '#0284c7',
-          700: '#0369a1',
-          800: '#075985',
-          900: '#0c4a6e'
+          50: '#eef2ff',
+          100: '#e0e7ff',
+          200: '#c7d2fe',
+          300: '#a5b4fc',
+          400: '#818cf8',
+          500: '#6366f1',
+          600: '#4f46e5',
+          700: '#4338ca',
+          800: '#3730a3',
+          900: '#312e81'
         },
         secondary: {
-          50: '#fefce8',
-          100: '#fef9c3',
-          200: '#fef08a',
-          300: '#fde047',
-          400: '#facc15',
-          500: '#eab308',
-          600: '#ca8a04',
-          700: '#a16207',
-          800: '#854d0e',
-          900: '#713f12'
+          50: '#f0fdfa',
+          100: '#ccfbf1',
+          200: '#99f6e4',
+          300: '#5eead4',
+          400: '#2dd4bf',
+          500: '#14b8a6',
+          600: '#0d9488',
+          700: '#0f766e',
+          800: '#115e59',
+          900: '#134e4a'
         },
         success: {
           50: '#f0fdf4',
@@ -55,22 +55,22 @@ module.exports = {
           800: '#991b1b',
           900: '#7f1d1d'
         },
-        // Additional cartoon colors
-        'cartoon-blue': '#58CC02',
-        'cartoon-green': '#89E219',
-        'cartoon-orange': '#FF9600',
-        'cartoon-purple': '#CE82FF',
-        'cartoon-pink': '#FF69B4',
-        'cartoon-red': '#FF4B4B',
-        'cartoon-yellow': '#FFC800',
-        'cartoon-gray': '#777777',
-        'cartoon-light': '#F7F7F7',
-        'cartoon-dark': '#37464F'
+        // Map legacy cartoon tokens to brand-cohesive values
+        'cartoon-blue': '#6366f1',
+        'cartoon-green': '#22c55e',
+        'cartoon-orange': '#f59e0b',
+        'cartoon-purple': '#8b5cf6',
+        'cartoon-pink': '#ec4899',
+        'cartoon-red': '#ef4444',
+        'cartoon-yellow': '#fbbf24',
+        'cartoon-gray': '#64748b',
+        'cartoon-light': '#f8fafc',
+        'cartoon-dark': '#0f172a'
       },
       fontFamily: {
-        'cartoon': ['Comic Sans MS', 'cursive'],
-        'sans': ['Inter', 'system-ui', 'sans-serif'],
-        'fun': ['Nunito', 'Comic Sans MS', 'cursive']
+        'sans': ['Inter', 'Noto Sans SC', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'system-ui', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'sans-serif'],
+        'fun': ['Inter', 'Noto Sans SC', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'system-ui', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'sans-serif'],
+        'cartoon': ['Inter', 'Noto Sans SC', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'system-ui', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'sans-serif']
       },
       animation: {
         'bounce-in': 'bounceIn 0.5s ease-in-out',
@@ -127,14 +127,14 @@ module.exports = {
         }
       },
       boxShadow: {
-        'cartoon': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06), 0 0 0 3px rgba(59, 130, 246, 0.1)',
-        'cartoon-lg': '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05), 0 0 0 3px rgba(59, 130, 246, 0.1)',
+        'cartoon': '0 1px 2px rgba(0,0,0,0.08), 0 4px 12px rgba(0,0,0,0.06)',
+        'cartoon-lg': '0 2px 4px rgba(0,0,0,0.08), 0 8px 20px rgba(0,0,0,0.08)',
         'success': '0 0 0 3px rgba(34, 197, 94, 0.2)',
         'danger': '0 0 0 3px rgba(239, 68, 68, 0.2)'
       },
       borderRadius: {
-        'cartoon': '20px',
-        'cartoon-lg': '30px'
+        'cartoon': '12px',
+        'cartoon-lg': '16px'
       }
     }
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2268,10 +2268,15 @@
     source-map-js "^1.2.1"
     tailwindcss "4.1.11"
 
-"@tailwindcss/oxide-win32-x64-msvc@4.1.11":
+"@tailwindcss/oxide-linux-x64-gnu@4.1.11":
   version "4.1.11"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.11.tgz"
-  integrity sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg==
+  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.11.tgz"
+  integrity sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==
+
+"@tailwindcss/oxide-linux-x64-musl@4.1.11":
+  version "4.1.11"
+  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.11.tgz"
+  integrity sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==
 
 "@tailwindcss/oxide@4.1.11":
   version "4.1.11"
@@ -6948,10 +6953,15 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lightningcss-win32-x64-msvc@1.30.1:
+lightningcss-linux-x64-gnu@1.30.1:
   version "1.30.1"
-  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz"
-  integrity sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz"
+  integrity sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==
+
+lightningcss-linux-x64-musl@1.30.1:
+  version "1.30.1"
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz"
+  integrity sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==
 
 lightningcss@1.30.1:
   version "1.30.1"


### PR DESCRIPTION
**请确认以下内容并填写相关信息：**

### 关联 Issue  
<!-- 如果该PR解决了某个Issue，请在此链接，如 "Closes #123" -->

### 变更描述  
根据用户要求，统一了前端应用的配色和字体。
- 引入了新的品牌调色板（主色为紫色系，辅色为青色系），并更新了 `tailwind.config.js`。
- 将原有的 `cartoon-*` 颜色和字体映射到新的品牌风格，以确保兼容性并消除旧的卡通风格。
- 全局字体栈统一为 `Inter` 和 `Noto Sans SC`，并在 `index.css` 中添加了基础排版样式。
- 更新了 `public/index.html` 中的主题颜色元标签。

### 测试说明  
1.  启动前端应用。
2.  验证所有页面元素（文本、按钮、背景等）是否已应用新的统一配色方案。
3.  检查字体是否已统一为 `Inter` 和 `Noto Sans SC` 系列。
4.  特别检查之前使用 `cartoon-*` 样式的组件，确保其显示正常且符合新主题。
5.  确认应用构建成功，无样式相关的错误。

### 完成情况清单  
- [x] 代码已经过自我检查，遵循项目代码规范  
- [ ] 已添加必要的单元测试，且所有测试用例均通过  
- [ ] 文档（如有）已更新，例如README或用户指南  
- [x] 在本地或测试环境中验证通过，确保变更符合预期  

### 待确认事项  
无

---
<a href="https://cursor.com/background-agent?bcId=bc-6e74fc7f-7957-4e20-a447-6c1829679492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e74fc7f-7957-4e20-a447-6c1829679492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

